### PR TITLE
SILA-3001: Receive only users should be able to request KYC directly instead of adding controlling officer and administrator issue has been resolved.

### DIFF
--- a/src/components/layout/NavbarUsers.js
+++ b/src/components/layout/NavbarUsers.js
@@ -23,7 +23,9 @@ const NavbarUsers = () => {
       settings: { ...app.settings, 
         flow: activeUser.flow,
         kybHandle: activeUser && activeUser.business ? activeUser.handle : false,
-        kybAdminHandle: activeUser && activeUser.admin ? activeUser : activeUser && activeUser.business && !activeUser.certified && app.users.some(u => u.admin && u.business_handle === activeUser.handle) ? app.users.find(u => u.admin && u.business_handle === activeUser.handle).handle : false
+        kybAdminHandle: activeUser && activeUser.admin ? activeUser : activeUser && activeUser.business && !activeUser.certified && app.users.some(u => u.admin && u.business_handle === activeUser.handle) ? app.users.find(u => u.admin && u.business_handle === activeUser.handle).handle : false,
+        preferredKycLevel: activeUser.kycLevel ? activeUser.kycLevel : false,
+        preferredKybLevel: activeUser.kybLevel ? activeUser.kybLevel : false
       },
       users: app.users.map(({ active, ...u }) => u.handle === handle ? { ...u, active: true } : u)
     }, () => {

--- a/src/views/kyb/BusinessMembers.js
+++ b/src/views/kyb/BusinessMembers.js
@@ -195,7 +195,7 @@ const BusinessMembers = ({ page, previous, next, isActive }) => {
 
       <Pagination
         previous={previous}
-        next={members.length && rolesAndMembers.filter(member => member.label && isRoleRequired(member)).length === 0 ? next : undefined}
+        next={app.settings.preferredKybLevel === 'RECEIVE_ONLY' ? next : members.length && rolesAndMembers.filter(member => member.label && isRoleRequired(member)).length === 0 ? next : undefined}
         currentPage={page} />
 
     </Container>


### PR DESCRIPTION
Hi @amack300,

- Receive only users should be able to `request KYC` directly instead of adding `controlling` officer and `administrator` issue has been resolved.

Thanks!