### PR TITLE
SILA-3026: Instant ACH in KYC level dropdown take that out as that feature from Demo 3.4

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -23,11 +23,12 @@ export const KYC_ARRAY = [{
   {
     value: 'RECEIVE_ONLY',
     label: 'Receive Only'
-  },
-  {
-    value: 'INSTANT-ACH',
-    label: 'Instant ACH'
   }
+  // DO NOT remove below lines, it will be release in next future version.
+  // {
+  //   value: 'INSTANT-ACH',
+  //   label: 'Instant ACH'
+  // }
 ];
 
 export const KYB_ARRAY = [{

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -80,7 +80,7 @@ export default [
     path: '/register_user',
     component: RegisterUser,
     tips: [
-      "If registering with Instant ACH, look for a text message to the number provided in order to opt-in for SMS notifications!",
+      //"If registering with Instant ACH, look for a text message to the number provided in order to opt-in for SMS notifications!",
       "Editing registered data is great for when a KYC fails as a result of a potential mis-key."
     ]
   },


### PR DESCRIPTION
Hi @amack300,

FYI, as per Ankur's slack message, 
- `Instant ACH` in KYC level dropdown, take that out from demo 3.4 release and that feature should go out with Demo 3.5
-  Also comment out the Instant ACH related in `Tips` message as well.

Thanks!
