### PR TITLE
SILA-3036: Resolved issue User navigates back to home screen after adding controlling officer.

### DIFF
--- a/src/components/kyb/LinkMemberForm.js
+++ b/src/components/kyb/LinkMemberForm.js
@@ -27,7 +27,7 @@ const LinkMemberForm = ({ member, onLinked, onUnlinked, onShowImDone }) => {
       const res = await api.linkBusinessMember(activeUser.handle, activeUser.private_key, businessUser.handle, businessUser.private_key, role.name, undefined, details, ownership_stake);
       if (res.data.success) {
         result.alert = { message: `Successfully linked as a ${role.label}!`, type: 'success' };
-        result.activeUser = role.name === 'administrator' ? activeUser : (role.name === 'controlling_officer' || role.name === 'beneficial_owner') ? user : app.activeUser;
+        result.activeUser = role.name === 'administrator' ? user ? user : activeUser : app.activeUser;
         if (onLinked) onLinked({ handle: activeUser.handle, role: role.name });
         if (ownershipStake) setOwnershipStake(0);
       } else {
@@ -35,7 +35,7 @@ const LinkMemberForm = ({ member, onLinked, onUnlinked, onShowImDone }) => {
       }
       setAppData({
         settings: role.name === 'administrator' ? { ...app.settings, kybAdminHandle: activeUser.handle } : app.settings,
-        users: (role.name === 'controlling_officer' || role.name === 'beneficial_owner') ? app.users.map(u => u.handle === activeUser.handle ? { ...u, ...user, admin: true } : u) : app.users.map(u => u.handle === activeUser.handle ? { ...u, admin: true } : u),
+        users: user ? app.users.map(u => u.handle === activeUser.handle ? { ...u, ...user, admin: true } : u) : app.users.map(u => u.handle === activeUser.handle ? { ...u, admin: true } : u),
         responses: [{
           endpoint: '/link_business_member',
           result: JSON.stringify(res, null, '\t')
@@ -92,6 +92,7 @@ const LinkMemberForm = ({ member, onLinked, onUnlinked, onShowImDone }) => {
   };
 
   const updateActiveUser = (role, user) => {
+    if (user && role && role.name === 'administrator') user.admin = true;
     if (onShowImDone) onShowImDone(true);
     setMoreInfoNeeded(false);
     hasRole(role.name) ? unlinkMember(role) : linkMember(role, user);

--- a/src/components/kyb/MemberKYBForm.js
+++ b/src/components/kyb/MemberKYBForm.js
@@ -218,7 +218,7 @@ const MemberKYBForm = ({ handle, activeMember, currentRole, moreInfoNeeded, onEr
         }
         setAppData({
           ...appData,
-          responses: [...app.responses, ...updatedResponses]
+          responses: [...updatedResponses, ...app.responses]
         }, () => {
           updateApp({ ...result });
           if (updateSuccess) onSuccess(currentRole, updatedEntityData);
@@ -282,7 +282,7 @@ const MemberKYBForm = ({ handle, activeMember, currentRole, moreInfoNeeded, onEr
           }, ...app.responses]
         }, () => {
           updateApp({ ...result });
-          if (res.data.success && onSuccess) onSuccess(entity);
+          if (res.data.success && onSuccess) onSuccess(currentRole, entity);
         });
       } catch (err) {
         console.log('  ... looks like we ran into an issue!');

--- a/src/components/register/RegisterUserForm.js
+++ b/src/components/register/RegisterUserForm.js
@@ -19,6 +19,7 @@ const RegisterUserForm = ({ className, handle, children, onError, onSuccess, onS
   const [errors, setErrors] = useState({});
   const [loaded, setLoaded] = useState(true);
   const [preferredKyc, setPreferredKyc] = useState(app.activeUser.kycLevel || app.settings.preferredKycLevel);
+  const [reloadUUID, setReloadUUID] = useState(false);
 
   const register = async (e) => {
     console.log('\n*** BEGIN REGISTER USER ***');
@@ -286,6 +287,7 @@ const RegisterUserForm = ({ className, handle, children, onError, onSuccess, onS
           appData = {
             users: app.users.map(({ active, ...u }) => u.handle === app.activeUser.handle ? { ...u, ...updatedEntityData } : u),
           };
+          setReloadUUID(true);
           if (Object.keys(errors).length) setErrors({});
         } else if ( Object.keys(validationErrors).length ) {
           setErrors(validationErrors);
@@ -294,7 +296,7 @@ const RegisterUserForm = ({ className, handle, children, onError, onSuccess, onS
         }
         setAppData({
           ...appData,
-          responses: [...app.responses, ...updatedResponses],
+          responses: [...updatedResponses, ...app.responses],
           settings: { ...app.settings, preferredKycLevel: preferredKyc }
         }, () => {
           updateApp({ ...result });
@@ -397,7 +399,7 @@ const RegisterUserForm = ({ className, handle, children, onError, onSuccess, onS
       {preferredKyc === RECEIVE_ONLY_KYC && <ReceiveOnlyKYCForm errors={errors} app={app} isHide={(app.activeUser && app.activeUser.kycLevel === RECEIVE_ONLY_KYC)} />}
       {preferredKyc === INSTANT_ACH_KYC && <InstantAchKYCForm errors={errors} app={app} isHide={(app.activeUser && app.activeUser.kycLevel === INSTANT_ACH_KYC)} />}
       {preferredKyc && (app.activeUser && app.activeUser.kycLevel !== preferredKyc) && <div className="d-flex mb-md-5"><Button type="submit" className="ml-auto" disabled={!(app.activeUser && app.activeUser.kycLevel !== app.settings.preferredKycLevel)}>Add data</Button></div>}
-      {app.activeUser && app.activeUser.handle && <RegisterDataForm errors={errors} onConfirm={onConfirm} onLoaded={(isLoaded) => setLoaded(isLoaded)} onErrors={(errorsObj) => { setErrors(errorsObj); setValidated(true); } } />}
+      {app.activeUser && app.activeUser.handle && <RegisterDataForm errors={errors} onConfirm={onConfirm} onLoaded={(isLoaded) => setLoaded(isLoaded)} onErrors={(errorsObj) => { setErrors(errorsObj); setValidated(true); } } reloadUUID={reloadUUID} onReloadedUUID={(isReloaded) => setReloadUUID(isReloaded)} />}
 
       {children}
     </Form>

--- a/src/views/kyb/RegisterMember.js
+++ b/src/views/kyb/RegisterMember.js
@@ -36,9 +36,9 @@ const RegisterMember = ({ page, location, history }) => {
     }
   };
 
-  const handleActiveUser = (user) => {
-    if (currentRole === 'administrator' || selectedRoles.some(role => role === 'administrator')) user.admin = true;
-    if (app.settings.kybHandle) user.business_handle = app.settings.kybHandle;
+  const handleActiveUser = (r, user) => {
+    if (user && (currentRole === 'administrator' || selectedRoles.some(role => role === 'administrator'))) user.admin = true;
+    if (user && app.settings.kybHandle) user.business_handle = app.settings.kybHandle;
     setActiveUser(user);
     setAppData({ users: app.users.some(u => u.handle === user.handle) ? app.users.map(u => u.handle === user.handle ? { ...u, ...user } : u) : [...app.users, user] });
   };
@@ -76,7 +76,7 @@ const RegisterMember = ({ page, location, history }) => {
           :
           <div className="mb-5 loaded position-relative select-menu-height" style={{ zIndex: 4 }}>
             <p className="text-lg text-muted mb-4 loaded">Select the user you wish to link to the business.</p>
-            <SelectMenu fullWidth title="Choose a user..." options={app.users.filter(user => !user.business).map(user => ({ label: `${user.firstName} ${user.lastName} (${user.handle})`, value: user.handle }))} onChange={(handle) => handleActiveUser(app.users.find(user => user.handle === handle))} />
+            <SelectMenu fullWidth title="Choose a user..." options={app.users.filter(user => !user.business).map(user => ({ label: `${user.firstName} ${user.lastName} (${user.handle})`, value: user.handle }))} onChange={(handle) => handleActiveUser(undefined, app.users.find(user => user.handle === handle))} />
           </div>}
 
       </div>}


### PR DESCRIPTION
Hi @amack300,

The following issues have been resolved in this PR.

- Resolved issue User navigates back to the home screen after adding a `controlling officer`.
- `KYB` flow, the user completed request `KYC` and come back on the `Register Data` page using the bottom `Back` button in this case in the Register Data page `Legal Company Name` shows empty even user has filled during registration.
- Add a `controlling officer` and choose an `existing user` in this case after choosing user linked but redirecting to the home page this issue is resolved.
- In the `Response` panel few `API` endpoints not showing in the descending order issue was resolved.

Thanks!