### PR TITLE
SILA-3102: Transactions should be displayed for the selected wallet and selected account only in the Transact page.

### DIFF
--- a/src/assets/styles/_forms.scss
+++ b/src/assets/styles/_forms.scss
@@ -202,3 +202,12 @@ select.form-control option[value=""] {
 .custom-switch .custom-control-label::after {
   background-color: $white;
 }
+
+.custom-control-input[type=radio]:checked ~ .custom-control-label::before {
+  border-color: $primary;
+  background-color: $primary;
+}
+.custom-control-input[type=radio]:not(:checked) ~ .custom-control-label::after, .custom-control-input[type=radio]:not(:checked) ~ .custom-control-label::before {
+  border-color: $primary;
+  background-color: transparent;
+}

--- a/src/components/common/Loader.js
+++ b/src/components/common/Loader.js
@@ -2,10 +2,16 @@ import React from 'react';
 import { Spinner } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
-const Loader = ({ label, overlay, ...rest }) => (
+const Loader = ({ label, overlay, fixed, ...rest }) => (
   <div className={`loader overlay d-flex justify-content-center align-items-center text-center`}>
-    <Spinner animation="border" role="status" variant="primary" {...rest}><span className="sr-only">Loading....</span></Spinner>
-    {label && <p className="text-muted text-sm mt-2" dangerouslySetInnerHTML={{ __html: label }}></p>}
+    {fixed && <div className={'position-fixed vh-100'}>
+      <Spinner animation="border" role="status" variant="primary" {...rest}><span className="sr-only">Loading....</span></Spinner>
+      {label && <p className="text-muted text-sm mt-2" dangerouslySetInnerHTML={{ __html: label }}></p>}
+    </div>}
+    {!fixed && <>
+      <Spinner animation="border" role="status" variant="primary" {...rest}><span className="sr-only">Loading....</span></Spinner>
+      {label && <p className="text-muted text-sm mt-2" dangerouslySetInnerHTML={{ __html: label }}></p>}
+    </>}
   </div>
 );
 
@@ -17,7 +23,11 @@ Loader.propTypes = {
   /**
    * Display the spinner in an optional overlay.
    */
-  overlay: PropTypes.bool
+  overlay: PropTypes.bool,
+  /**
+   * Display the spinner in the middle of the screen along with position fixed.
+   */
+  fixed: PropTypes.bool
 };
 
 export default Loader;

--- a/src/components/kyb/RegisterBusinessForm.js
+++ b/src/components/kyb/RegisterBusinessForm.js
@@ -375,7 +375,7 @@ const RegisterBusinessForm = ({ className, children, onError, onSuccess, onShowK
 
   return (
     <Form noValidate className={className} validated={validated} autoComplete="off" onSubmit={register}>
-      {!loaded && <Loader overlay />}
+      {!loaded && <Loader overlay fixed />}
 
       <Form.Label className="text-muted mr-5">Please choose your preferred KYB level:</Form.Label>
       <SelectMenu fullWidth

--- a/src/components/register/RegisterUserForm.js
+++ b/src/components/register/RegisterUserForm.js
@@ -383,7 +383,7 @@ const RegisterUserForm = ({ className, handle, children, onError, onSuccess, onS
 
   return (
     <Form noValidate className={className} validated={validated} autoComplete="off" onSubmit={register}>
-      {!loaded && <Loader overlay />}
+      {!loaded && <Loader overlay fixed />}
 
       <Form.Label className="text-muted mr-5">Please choose your preferred KYC level:</Form.Label>
       <SelectMenu fullWidth

--- a/src/views/Transact.js
+++ b/src/views/Transact.js
@@ -149,6 +149,8 @@ const Transact = ({ page, previous, next, isActive }) => {
     updateApp({ transactions: false });
     try {
       const res = await api.getTransactions(app.activeUser.handle, app.activeUser.private_key, {
+        bank_account_name: account.account_name,
+        blockchain_address: wallet.blockchain_address,
         per_page: 50
       });
       let result = {};


### PR DESCRIPTION
Hi @amack300,

Here, the following things have been fixed - 

- Currently on the production demo app, we're showing all the user `transactions` in the Transactions modal, so as per the `QA` now I've fixed and shown only selected `Bank account` and selected `Wallet` transactions in the Transactions modal on the `Transact` page.
- Also I've fixed the radio button `color` overriding issue in the `Add Business Member` page for `an existing user` or `add a new user` radio button.

Thanks!