### PR TITLE
SILA-3227: The red border is showing on the account name textbox when clicking on the link bank account button issue has been resolved.

### DIFF
--- a/src/components/accounts/LinkAccountModal.js
+++ b/src/components/accounts/LinkAccountModal.js
@@ -82,7 +82,7 @@ const LinkAccountModal = ({ show, onSuccess }) => {
 
           <Form.Group className="mb-3">
             <Form.Label htmlFor="accountName">Account Name</Form.Label>
-            <Form.Control required isInvalid={errors.account_name}
+            <Form.Control isInvalid={errors.account_name}
               id="accountName"
               placeholder="Checking"
               aria-label="Account Name"


### PR DESCRIPTION
Hi @amack300,

- The red border is showing on the account name textbox when clicking on the link bank account button issue has been resolved.

Thanks!