### PR TITLE
SILA-3237: SMS verification for Instant ACH.

### DIFF
--- a/src/views/kyc/RegisterUser.js
+++ b/src/views/kyc/RegisterUser.js
@@ -47,7 +47,7 @@ const RegisterUser = ({ page, previous, next, isActive }) => {
 
       <Pagination
         previous={previous}
-        next={isActive ? next : undefined}
+        next={isActive ? (app.settings.preferredKycLevel === 'INSTANT-ACH' && !app.activeUser.smsConfirmed) ? undefined : next : undefined}
         currentPage={page} />
 
       <KycModal show={show} onHide={() => setShow(false)} />


### PR DESCRIPTION
Hi @amack300,

For Instant ACH, if users verify SMS in order to proceed to the next step of the Demo, if a user is unable to verify SMS then the system should not allow the next step in Instant_ACH KYC type. 

Thanks!