### PR TITLE
SILA-3730: Add Additional wallet button label typo spell issue fixed.

### DIFF
--- a/src/views/Wallets.js
+++ b/src/views/Wallets.js
@@ -259,7 +259,7 @@ const Wallets = ({ page, previous, next, isActive }) => {
 
       <div className="d-flex mt-3">
         {app.alert.message && <AlertMessage message={app.alert.message} type={app.alert.type} />}
-        <Button onClick={addWallet} className="ml-auto">Add Additonal Wallet <i className="fas fa-plus-circle ml-2"></i></Button>
+        <Button onClick={addWallet} className="ml-auto">Add Additional Wallet <i className="fas fa-plus-circle ml-2"></i></Button>
       </div>
 
       <Pagination


### PR DESCRIPTION
Hi @amack300,

`Add Additional wallet` button label typo spell issue fixed.

Thanks!