### PR TITLE
SILA-4088: Hook up plaid endpoints and show responses for generating a processor token.

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,46 @@
+import { getQueryString } from '../../src/utils';
+
+export const request = async (params) => {
+  var method = params.method || 'GET';
+  var qs = '';
+  var body;
+  var headers = params.headers || {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  if (['GET'].indexOf(method) > -1 && params.data)
+    qs = '?' + getQueryString(params.data);
+  else
+    body = JSON.stringify(params.data);
+
+  var url = params.url + qs;
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body
+    });
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    return error;
+  }
+};
+
+const api = {
+  get: params => request(Object.assign({
+    method: 'GET'
+  }, params)),
+  post: params => request(Object.assign({
+    method: 'POST'
+  }, params)),
+  put: params => request(Object.assign({
+    method: 'PUT'
+  }, params)),
+  delete: params => request(Object.assign({
+    method: 'DELETE'
+  }, params)),
+};
+
+export default api;

--- a/src/api/plaid.js
+++ b/src/api/plaid.js
@@ -1,0 +1,45 @@
+import plaidApi from './api';
+
+const createLinkToken = async (data) => {
+  try {
+    const response = await plaidApi.post({
+      url: '/link/token/create',
+      data: data
+    });
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const exchangeToken = async (data) => {
+  try {
+    const response = await plaidApi.post({
+      url: '/item/public_token/exchange',
+      data: data
+    });
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const createProcessorToken = async (data) => {
+  try {
+    const response = await plaidApi.post({
+      url: '/processor/token/create',
+      data: data
+    });
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const plaid = {
+  createLinkToken,
+  exchangeToken,
+  createProcessorToken
+};
+
+export default plaid;

--- a/src/components/accounts/GenerateProcessorTokenModal.js
+++ b/src/components/accounts/GenerateProcessorTokenModal.js
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { Modal, Container, Row, Col, Button, Card } from 'react-bootstrap';
+
+import plaidApi from '../../../src/api/plaid';
+
+const GenerateProcessorTokenModal = ({ show, onHide }) => {
+  const [linkToken, setLinkToken] = useState(false);
+  const [linkResponse, setLinkResponse] = useState(false);
+  const [publicToken, setPublicToken] = useState(false);
+  const [accountId, setAccountId] = useState(false);
+  const [publicResponse, setPublicResponse] = useState(false);
+  const [accessToken, setAccessToken] = useState(false);
+  const [accessResponse, setAccessResponse] = useState(false);
+  const [processorToken, setProcessorToken] = useState(false);
+  const [processorResponse, setProcessorResponse] = useState(false);
+
+  const createLinkToken = async () => {
+    try {
+      const response = await plaidApi.createLinkToken({
+        'client_name': 'Sila Demo',
+        'country_codes': ['US'],
+        'language': 'en',
+        'user': {
+          'client_user_id': 'sila'
+        },
+        'products': ['auth']
+      });
+      setLinkResponse(JSON.stringify(response, null, '\t'));
+      
+      if (response && response.status === 200 && response.data && response.data.link_token) {
+        setLinkToken(response.data.link_token);
+        const method = 'POST';
+        const headers = {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        };
+        const body = JSON.stringify({
+          link_token: response.data.link_token,
+          initial_products: ['transactions'],
+          institution_id: 'ins_109508',
+          credentials: {
+            username: 'user_good',
+            password: 'pass_good'
+          }
+        });
+        const public_res = await fetch('https://sandbox.plaid.com/link/item/create', { method, headers, body });
+        const result = await public_res.json();
+        setPublicResponse(JSON.stringify(result, null, '\t'));
+        if (result && result.public_token) {
+          setPublicToken(result.public_token);
+          setAccountId(result.accounts[0]['account_id']);
+        }
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const exchangeToken = async () => {
+    try {
+      const response = await plaidApi.exchangeToken({'public_token': publicToken});
+      setAccessResponse(JSON.stringify(response, null, '\t'));
+      setAccessToken(response.data.access_token);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const createProcessorToken = async () => {
+    try {
+      const response = await plaidApi.createProcessorToken({
+        'accessToken': accessToken,
+        'accountID': accountId,
+        'processor': 'sila_money'
+      });
+      setProcessorResponse(JSON.stringify(response, null, '\t'));
+      setProcessorToken(response.data.processor_token);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return (
+    <Modal centered
+      show={show}
+      size="lg"
+      aria-labelledby="generate-processor-token-modal-title"
+      onHide={onHide}>
+      <Modal.Header className="text-left border-bottom p-4" closeButton>
+        <Modal.Title id="generate-processor-token-modal-title" className="text-lgr">Generate a Plaid Processor Token</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="p-4">
+        <Container className="p-4">
+          <Row>
+            <Col className="mx-auto" md="6">
+              <h2 className="mb-4 text-center text-primary">Plaid Test</h2>
+              <Card as="aside">
+                <Card.Header as="header" className="p-4">
+                  <h4>Generate A Link Token</h4>
+                </Card.Header>
+                <Card.Body as="section" className="p-4">
+                  <p className={`mb-0 ${linkToken ? 'text-success' : 'text-muted font-italic'}`}>{linkToken || 'link-sandbox-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'}</p>
+                  <p className={`mb-0 ${publicToken ? 'text-success' : 'text-muted font-italic'}`}>{publicToken || 'public-sandbox-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'}</p>
+                  <p className={`mb-0 ${accessToken ? 'text-success' : 'text-muted font-italic'}`}>{accessToken || 'access-sandbox-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'}</p>
+                  <p className={`mb-0 ${processorToken ? 'text-success' : 'text-muted font-italic'}`}>{processorToken || 'processor-sandbox-xxxxx-xxxxx'}</p>
+                </Card.Body>
+                <Card.Footer as="footer" className="p-4">
+                  <Button onClick={createLinkToken} className="ml-auto mb-3">Generate Link Token</Button>
+                  {linkToken && publicToken && <Button onClick={exchangeToken} className="ml-auto mb-3">Generate an Access Token</Button>}
+                  {accessToken && <Button onClick={createProcessorToken} className="ml-auto mb-3">Create Processor token</Button>}
+                </Card.Footer>
+              </Card>
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <h5 className="mt-5">Plaid Response:</h5>
+              <pre className="w-100 border p-4 rounded">{linkResponse || 'Wating for link response...'}</pre>
+              {publicResponse && <pre className="w-100 border p-4 rounded">{publicResponse || 'Wating for public response...'}</pre>}
+              {accessResponse && <pre className="w-100 border p-4 rounded">{accessResponse || 'Wating for access response...'}</pre>}
+              {processorResponse && <pre className="w-100 border p-4 rounded">{processorResponse || 'Wating for processor response...'}</pre>}
+            </Col>
+          </Row>
+        </Container>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default GenerateProcessorTokenModal;

--- a/src/components/accounts/ProcessorTokenFlowModal.js
+++ b/src/components/accounts/ProcessorTokenFlowModal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Modal, Container, Row, Col, Button } from 'react-bootstrap';
 
-const ProcessorTokenFlowModal = ({ show, onShowProcessorTokenModal, onHide }) => {
+const ProcessorTokenFlowModal = ({ show, onShowProcessorTokenModal, onShowGenerateProcessorTokenModal, onHide }) => {
   return (
     <Modal centered
       show={show}
@@ -21,7 +21,7 @@ const ProcessorTokenFlowModal = ({ show, onShowProcessorTokenModal, onHide }) =>
             </Col>
           </Row>
           <Row className="mb-4 align-items-center">
-            <Col sm={4}><Button block className="mb-2 p-3">Generate Processor Token</Button></Col>
+            <Col sm={4}><Button onClick={onShowGenerateProcessorTokenModal} block className="mb-2 p-3">Generate Processor Token</Button></Col>
             <Col sm={8}>
               <p className="text-muted">With this flow, you will be able to generate your own processor token using your Plaid Sandbox credentials. Your credentials are held locally, and are completely secure. We will make calls on your behalf, which allows you to see the API responses in real-time. </p>
             </Col>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -44,3 +44,10 @@ export const b64toBlob = (b64Data, contentType='', sliceSize=512) => {
   const blob = new Blob(byteArrays, {type: contentType});
   return blob;
 }
+
+export const getQueryString = (params) => {
+  var esc = encodeURIComponent;
+  return Object.keys(params)
+    .map(k => esc(k) + '=' + esc(params[k]))
+    .join('&');
+};

--- a/src/views/Accounts.js
+++ b/src/views/Accounts.js
@@ -10,6 +10,7 @@ import LinkAccountModal from '../components/accounts/LinkAccountModal';
 import ProcessorTokenModal from '../components/accounts/ProcessorTokenModal';
 import InstitutionsModal from '../components/accounts/InstitutionsModal';
 import ProcessorTokenFlowModal from '../components/accounts/ProcessorTokenFlowModal';
+import GenerateProcessorTokenModal from '../components/accounts/GenerateProcessorTokenModal';
 import ConfirmModal from '../components/common/ConfirmModal';
 
 const Accounts = ({ page, previous, next, isActive }) => {
@@ -27,6 +28,7 @@ const Accounts = ({ page, previous, next, isActive }) => {
   const [isFetching, setIsFetching] = useState(false);
   const [errors, setErrors] = useState(false);
   const [processorTokenFlowModal, setProcessorTokenFlowModal] = useState(false);
+  const [generateProcessorTokenModal, setGenerateProcessorTokenModal] = useState(false);
   const tbodyRef = useRef()
   let result = {};
   let appData = {};
@@ -285,6 +287,11 @@ const Accounts = ({ page, previous, next, isActive }) => {
     updateApp({ manageProcessorToken: true });
   }
 
+  const onShowGenerateProcessorTokenModal = () => {
+    setProcessorTokenFlowModal(false);
+    setGenerateProcessorTokenModal(true);
+  }
+
   useEffect(() => {
     getAccounts();
   }, [app.activeUser]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -431,7 +438,9 @@ const Accounts = ({ page, previous, next, isActive }) => {
 
       <InstitutionsModal institutions={institutions} errors={errors} isFetching={isFetching} show={showInstitution} onSearch={(filter, page) => getInstitutions(filter, page)} onClose={() => setShowInstitution(false)} />
 
-      <ProcessorTokenFlowModal show={processorTokenFlowModal} onShowProcessorTokenModal={onShowProcessorTokenModal} onHide={() => setProcessorTokenFlowModal(false)} />
+      <ProcessorTokenFlowModal show={processorTokenFlowModal} onShowProcessorTokenModal={onShowProcessorTokenModal} onShowGenerateProcessorTokenModal={onShowGenerateProcessorTokenModal} onHide={() => setProcessorTokenFlowModal(false)} />
+
+      <GenerateProcessorTokenModal show={generateProcessorTokenModal} onHide={() => setGenerateProcessorTokenModal(false)} />
 
     </Container>
   );


### PR DESCRIPTION
Hi @amack300,

Hook up plaid endpoints and show responses for generating a processor token in the UI, the UI is for now only for testing purposes and will modify as per the Figma screens.

Thanks!